### PR TITLE
Added support for ShuttleXpress (and then some)

### DIFF
--- a/99-ShuttlePRO.rules
+++ b/99-ShuttlePRO.rules
@@ -7,6 +7,8 @@
 ACTION=="add", ATTRS{name}=="Contour Design ShuttlePRO v2", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttlePRO_v2-event-if00 &"
 ACTION=="remove", ATTRS{name}=="Contour Design ShuttlePRO v2", RUN+="/usr/bin/pkill shuttlepro"
 
-#ShuttleXpress
-ACTION=="add", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttleXpress-event-if00 &" 
+#ShuttleXpress / SpaceShuttle A/V
+ACTION=="add", ATTRS{name}=="Contour Design, Inc. ShuttleXpress", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttleXpress-event-if00 &" 
+ACTION=="add", ATTRS{name}=="CAVS SpaceShuttle A/V", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-CAVS_SpaceShuttle_A_V-event-if00 &"
 ACTION=="remove", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", RUN+="/usr/bin/pkill shuttlepro"
+

--- a/99-ShuttlePRO.rules
+++ b/99-ShuttlePRO.rules
@@ -1,6 +1,12 @@
 
-# Allows global read access to any ShuttlePRO device
+# Allows global read access to any ShuttlePRO device and autostarts shuttle app
 
 # install this file in /etc/udev/rules.d
 
-ATTRS{name}=="Contour Design ShuttlePRO v2" MODE="0644"
+# ShuttlePRO
+ACTION=="add", ATTRS{name}=="Contour Design ShuttlePRO v2", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttlePRO_v2-event-if00 &"
+ACTION=="remove", ATTRS{name}=="Contour Design ShuttlePRO v2", RUN+="/usr/bin/pkill shuttlepro"
+
+#ShuttleXpress
+ACTION=="add", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttleXpress-event-if00 &" 
+ACTION=="remove", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", RUN+="/usr/bin/pkill shuttlepro"

--- a/99-ShuttlePRO.rules
+++ b/99-ShuttlePRO.rules
@@ -1,4 +1,3 @@
-
 # Allows global read access to any ShuttlePRO device and autostarts shuttle app
 
 # install this file in /etc/udev/rules.d
@@ -7,8 +6,11 @@
 ACTION=="add", ATTRS{name}=="Contour Design ShuttlePRO v2", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttlePRO_v2-event-if00 &"
 ACTION=="remove", ATTRS{name}=="Contour Design ShuttlePRO v2", RUN+="/usr/bin/pkill shuttlepro"
 
-#ShuttleXpress / SpaceShuttle A/V
-ACTION=="add", ATTRS{name}=="Contour Design, Inc. ShuttleXpress", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttleXpress-event-if00 &" 
+# SpaceShuttle
 ACTION=="add", ATTRS{name}=="CAVS SpaceShuttle A/V", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-CAVS_SpaceShuttle_A_V-event-if00 &"
+ACTION=="remove", ATTRS{name}=="CAVS SpaceShuttle A/V", RUN+="/usr/bin/pkill shuttlepro"
+
+# ShuttleXpress
+ACTION=="add", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0644", RUN+="/usr/local/bin/shuttle /dev/input/by-id/usb-Contour_Design_ShuttleXpress-event-if00 &" 
 ACTION=="remove", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", RUN+="/usr/bin/pkill shuttlepro"
 

--- a/README
+++ b/README
@@ -10,7 +10,9 @@ ShuttlePRO events can generate sequences of multiple keystrokes,
 including the pressing and releasing of modifier keys.  The binding
 can be selected based on the title of the window which is focused.
 
-Build instructions:
+To install type ./install from this directyory.
+
+You can also build manually:
 
 # apt-get install build-essential libx11-dev libxtst-dev
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ShuttlePRO
 ==========
 
-User program for interpreting key, shuttle, and jog events from a Contour Design ShuttlePRO v2
+User program for interpreting key, shuttle, and jog events from a Contour Design ShuttlePRO v2 and ShuttleXpress S-XPRS

--- a/example.shuttlerc
+++ b/example.shuttlerc
@@ -45,11 +45,12 @@
 #          K10        K11
 #         K12          K13
 
-# The keys on the Contour Shuttle Pro v2 are arranged like this:
+# The keys on the Contour Shuttle Pro v2 / SpaceShuttle are arranged like this:
 #
-#        K5  K6  K7  K8  K9
+#            K6  K7  K8
 #
-#               Jog   
+#           K5  Jog   K9
+#  
 
 # After the name of the key being bound, the remainder of the line is
 # the sequence of X KeySyms which will be generated when that event is
@@ -114,12 +115,40 @@
  
  JL XK_KP_4     # Frame reverse
  JR XK_KP_1     # Frame forward
+ 
+[Cinelerra-CV Resources] ^Cinelerra-CV: Resources$
+ # use [Default], avoiding main Cinelerra rule
 
+[Cinelerra-CV Load] ^Cinelerra-CV: Load$
+ # use [Default], avoiding main Cinelerra rule
 
+[Cinelerra-CV] ^Cinelerra-CV: [^[:space:]]*$
+
+ K5 XK_KP_0     # Stop
+ K9 XK_KP_3     # Play
+ K6 XK_Home    # Beginning
+ K8 XK_End     # End
+ k7 "z"		# undo
+# K14 "["        # Toggle in
+# K15 "]"        # Toggle out
+
+ S-3 XK_KP_Add  # Fast reverse
+ S-2 XK_KP_6    # Play reverse
+ S-1 XK_KP_5    # Slow reverse
+ S0 XK_KP_0     # Stop
+ S1 XK_KP_2     # Slow forward
+ S2 XK_KP_3     # Play forward
+ S3 XK_KP_Enter # Fast forward
+ 
+ JL XK_KP_4     # Frame reverse
+ JR XK_KP_1     # Frame forward
 
 [Default]
+
  K6 XK_Button_1
- K7 XK_Button_2
+ K7 " "
  K8 XK_Button_3
- JL XK_Scroll_Up
- JR XK_Scroll_Down
+ JL XK_Left
+ JR XK_Right
+ K5 XK_Home
+ K9 XK_End

--- a/example.shuttlerc
+++ b/example.shuttlerc
@@ -45,6 +45,12 @@
 #          K10        K11
 #         K12          K13
 
+# The keys on the Contour Shuttle Pro v2 are arranged like this:
+#
+#        K5  K6  K7  K8  K9
+#
+#               Jog   
+
 # After the name of the key being bound, the remainder of the line is
 # the sequence of X KeySyms which will be generated when that event is
 # received.  Look up the KeySyms in /usr/include/X11/keysymdef.h.  In

--- a/install
+++ b/install
@@ -11,7 +11,16 @@ read -p  "Press enter to continue or ctrl+c to exit."
 make
 sudo cp 99-ShuttlePRO.rules /etc/udev/rules.d
 sudo make install
-cp example.shuttlerc $HOME/.shuttlerc
+
+shuttlerc="$HOME/.shuttlerc"
+
+if [ -e "$shuttlerc" ]
+then
+	echo "I see you already have a .shuttlerc file in your home directory."
+	echo "It will not be overwritten. Manually copy example.shuttlerc to $shuttlerc if you want to use it."
+else
+	cp example.shuttlerc $shuttlerc
+	echo "Confige file installed in $shuttlerc"
+fi
 
 echo "Install complete. You may now plug in your device."
-echo "Configuration options have been installed in $HOME/.shuttlerc"

--- a/install
+++ b/install
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Installs the shuttlepro application and config file
+# You will need to be in the sudoers file
+
+echo "You are about to build and install Contour device compatibility layer."
+echo "Please unplug your Contour device."
+echo "You will be asked for your sudo password."
+read -p  "Press enter to continue or ctrl+c to exit."
+
+make
+sudo cp 99-ShuttlePRO.rules /etc/udev/rules.d
+sudo make install
+cp example.shuttlerc $HOME/.shuttlerc
+
+echo "Install complete. You may now plug in your device."
+echo "Configuration options have been installed in $HOME/.shuttlerc"

--- a/shuttle
+++ b/shuttle
@@ -3,5 +3,11 @@
 MYUSER=($(users))
 FILE=$1
 
-su $MYUSER -c "DISPLAY=:0 /usr/local/bin/shuttlepro $FILE"
+while ! [ "$MYUSER" ]; do
+	sleep 10
+	MYUSER=($(users))
+done
 
+pkill shuttlepro
+
+su $MYUSER -c "DISPLAY=:0 /usr/local/bin/shuttlepro $FILE"

--- a/shuttle
+++ b/shuttle
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-exec shuttlepro /dev/input/by-id/usb-Contour_Design_ShuttlePRO_v2-event-if00
+MYUSER=($(users))
+FILE=$1
+
+su $MYUSER -c "DISPLAY=:0 /usr/local/bin/shuttlepro $FILE"
+


### PR DESCRIPTION
I will start off by saying "This app is awsome! Thanks!"

Anyway, I have a ShuttleXpress I am now using with ubuntu trusty. Using the comment posted at freecode (http://freecode.com/projects/shuttlepro) I updated some aspects of the shuttle app to 1. work with the Xpress and 2. to automatically start when you plug in your contour device

I am hoping to add some more to it as well. I will be using it in Audacity and will make a config for that available. I would also like to make a deb installer to make the install process smoother. 

Thanks!
