### PR TITLE
Various improvements

### DIFF
--- a/example.shuttlerc
+++ b/example.shuttlerc
@@ -2,29 +2,37 @@
 # Copyright 2013 Eric Messick (FixedImagePhoto.com/Contact)
 #
 # Lines in this file starting with # are comments.
-#
-#
+
 # This file is divided into paragraphs, each specifying the bindings to
 # be used when the keyboard focus is on a specific window.  The
 # paragraph is introduced with a line starting with [.  That line
 # contains the paragraph name (which is only used for debugging output
 # to help you in editing this file) followed by ], followed by a regular
-# expression.  When the title bar of the focused window matches the
+# expression.  When the class or name of the focused window matches the
 # regular expression (see regex(7)), the bindings in the paragraph will
 # be in effect.  The program tries these regular expressions in order,
-# and the first match is used.
+# and the first match is used.  It first tries to match the class
+# (WM_CLASS property) of the window, since that usually provides the
+# better clues for identifying an application. If that fails, it will
+# then also try to match the window's title (WM_NAME property).
+
+# NB: Try to be as specific with the regular expression as possible, in
+# order to prevent accidental matches.  Often an application uses its
+# name as the class name or in its title bar, in which case finding a
+# suitable regex should be relatively easy.  See below for some
+# examples.
 
 # If there is no regex on the line, like the [Default] line near the
-# bottom, the paragraph acts as a default.  Any window title which does
-# not match any regex will use the default bindings.  Any keys which are
-# not specified in the paragraph which does match will use the default
-# bindings for those keys.
+# bottom, the paragraph acts as a default.  Any window class and title
+# which does not match any regex will use the default bindings.  Any
+# keys which are not specified in the paragraph which does match will
+# use the default bindings for those keys.
 
 # While you are working on regular expressions to match your window
-# names, is is useful to see the window names and paragraph names which
-# the program finds as you generate ShuttlePRO events.  Run the shuttle
-# program in a terminal window and remove the comment character from the
-# following line:
+# names, is is useful to see the window names and classes, as well as
+# the paragraph names which the program finds as you generate ShuttlePRO
+# events.  Run the shuttle program in a terminal window and remove the
+# comment character from the following line:
 
 #DEBUG_REGEX
 
@@ -34,6 +42,12 @@
 # positions, S0 for the rest position in the center, and S1 through S7
 # for the clockwise positions.  The jog wheel emits two events named JL
 # and JR, for counter-clockwise and clockwise rotations respectively.
+
+# Some programs may expect the shuttle wheel to work like a secondary
+# jog wheel.  To accommodate these, key bindings can also be specified
+# using the incremental shuttle events IL and IR, which indicate
+# counter-clockwise and clockwise rotations, and work in the same
+# fashion as the jog wheel (albeit with a limited range of -7 .. 7).
 
 # The keys on the Contour Shuttle Pro v2 are arranged like this:
 #
@@ -80,6 +94,16 @@
 
 #DEBUG_STROKES
 
+# You can also use the following option to have the recognized key
+# bindings printed out as the program executes them, in the same format
+# as DEBUG_STROKES:
+
+#DEBUG_KEYS
+
+# NOTE: The debugging options can also be specified on the command line
+# using -d in conjunction with any of the letters r, s and k. Just -d
+# without any option letter turns on all debugging options.
+
 # As one of the main reasons to use a ShuttlePRO is video editing, I've
 # included a sample set of bindings for Cinelerra as an example.
 
@@ -110,6 +134,57 @@
  JR XK_KP_1     # Frame forward
 
 
+# AG <aggraef@gmail.com>: Here are some of the bindings that I use. They are
+# for the Shuttle Xpress, so they use only a limited set of buttons.
+
+# Shotcut (WM_CLASS is "shotcut")
+# see https://www.shotcut.org/howtos/keyboard-shortcuts/
+
+[Shotcut] ^shotcut$
+
+ K7 XK_space    # Play/Pause
+ K6 XK_Home     # Beginning
+ K8 XK_End      # End
+ K5 "I"         # Set In
+ K9 "O"         # Set Out
+
+# Shotcut uses the customary J-K-L shortcuts, each successive J or L key then
+# increments the playback speed in the corresponding direction. Thus we can
+# simply treat the shuttle like a secondary jog wheel here.
+ IL "J"         # Rewind
+ IR "L"         # Forward
+
+# The jog wheel moves single frames to the left or the right.
+ JL XK_Left     # Frame reverse
+ JR XK_Right    # Frame forward
+
+
+# Kdenlive has its own built-in support for the Shuttle, but as the
+# shuttlepro program blocks the device when it's running, we include
+# some sensible bindings here anyway (pretty much the same as Shotcut
+# above, but the shuttle has to be treated a little differently).
+
+[Kdenlive] ^kdenlive$
+
+ K7 XK_space    # Play/Pause
+ K6 XK_Home     # Beginning
+ K8 XK_End      # End
+ K5 "I"         # Set In
+ K9 "O"         # Set Out
+
+ S-3 "KJJJ"     # Rewind+2
+ S-2 "KJJ"      # Rewind+1
+ S-1 "KJ"       # Rewind
+ S0 "K"         # Stop
+ S1 "KL"        # Forward
+ S2 "KLL"       # Forward+1
+ S3 "KLLL"      # Forward+2
+
+ JL XK_Left     # Frame reverse
+ JR XK_Right    # Frame forward
+
+
+# Default (mouse emulation)
 
 [Default]
  K6 XK_Button_1

--- a/readconfig.c
+++ b/readconfig.c
@@ -68,6 +68,7 @@
 
 int debug_regex = 0;
 int debug_strokes = 0;
+int debug_keys = 0;
 
 char *
 allocate(size_t len)
@@ -703,6 +704,7 @@ read_config_file(void)
     free_all_translations();
     debug_regex = 0;
     debug_strokes = 0;
+    debug_keys = 0;
 
     while ((line=read_line(f, config_file_name)) != NULL) {
       //printf("line: %s", line);
@@ -751,6 +753,10 @@ read_config_file(void)
       }
       if (!strcmp(tok, "DEBUG_STROKES")) {
 	debug_strokes = 1;
+	continue;
+      }
+      if (!strcmp(tok, "DEBUG_KEYS")) {
+	debug_keys = 1;
 	continue;
       }
       which_key = tok;

--- a/readconfig.c
+++ b/readconfig.c
@@ -66,6 +66,10 @@
 
 #include "shuttle.h"
 
+int default_debug_regex = 0;
+int default_debug_strokes = 0;
+int default_debug_keys = 0;
+
 int debug_regex = 0;
 int debug_strokes = 0;
 int debug_keys = 0;
@@ -264,7 +268,7 @@ free_all_translations(void)
   last_translation_section = NULL;
 }
 
-static char *config_file_name = NULL;
+char *config_file_name = NULL;
 static time_t config_file_modification_time;
 
 static char *token_src = NULL;
@@ -702,9 +706,9 @@ read_config_file(void)
     }
 
     free_all_translations();
-    debug_regex = 0;
-    debug_strokes = 0;
-    debug_keys = 0;
+    debug_regex = default_debug_regex;
+    debug_strokes = default_debug_strokes;
+    debug_keys = default_debug_keys;
 
     while ((line=read_line(f, config_file_name)) != NULL) {
       //printf("line: %s", line);

--- a/readconfig.c
+++ b/readconfig.c
@@ -12,6 +12,7 @@
   [name] regex
   K<1..15> output
   S<-7..7> output
+  I<LR> output
   J<LR> output
 
   When focus is on a window whose title matches regex, the following
@@ -24,7 +25,7 @@
   translations for the named translation class.  The name is only used
   for debugging output, and needn't be unique.  The following lines
   with K, S, and J labels indicate what output should be produced for
-  the given keypress, shuttle position, or jog direction.
+  the given keypress, shuttle position, shuttle direction, or jog direction.
 
   output is a sequence of one or more key codes with optional up/down
   indicators, or strings of printable characters enclosed in double
@@ -193,6 +194,9 @@ new_translation_section(char *name, char *regex)
   for (i=0; i<NUM_SHUTTLES; i++) {
     ret->shuttle[i] = NULL;
   }
+  for (i=0; i<NUM_SHUTTLE_INCRS; i++) {
+    ret->shuttle_incr[i] = NULL;
+  }
   for (i=0; i<NUM_JOGS; i++) {
     ret->jog[i] = NULL;
   }
@@ -233,6 +237,9 @@ free_translation_section(translation *tr)
     }
     for (i=0; i<NUM_SHUTTLES; i++) {
       free_strokes(tr->shuttle[i]);
+    }
+    for (i=0; i<NUM_SHUTTLE_INCRS; i++) {
+      free_strokes(tr->shuttle_incr[i]);
     }
     for (i=0; i<NUM_JOGS; i++) {
       free_strokes(tr->jog[i]);
@@ -503,12 +510,18 @@ start_translation(translation *tr, char *which_key)
   first_release_stroke = 0;
   regular_key_down = 0;
   modifier_count = 0;
-  // JL, JR
   if (tolower(which_key[0]) == 'j' &&
       (tolower(which_key[1]) == 'l' || tolower(which_key[1]) == 'r') &&
       which_key[2] == '\0') {
+    // JL, JR
     k = tolower(which_key[1]) == 'l' ? 0 : 1;
     first_stroke = &(tr->jog[k]);
+  } else if (tolower(which_key[0]) == 'i' &&
+      (tolower(which_key[1]) == 'l' || tolower(which_key[1]) == 'r') &&
+      which_key[2] == '\0') {
+    // IL, IR
+    k = tolower(which_key[1]) == 'l' ? 0 : 1;
+    first_stroke = &(tr->shuttle_incr[k]);
   } else {
     n = 0;
     sscanf(which_key, "%c%d%n", &c, &k, &n);

--- a/readconfig.c
+++ b/readconfig.c
@@ -15,9 +15,9 @@
   I<LR> output
   J<LR> output
 
-  When focus is on a window whose title matches regex, the following
-  translation class is in effect.  An empty regex for the last class
-  will always match, allowing default translations.  Any output
+  When focus is on a window whose class or title matches regex, the
+  following translation class is in effect.  An empty regex for the last
+  class will always match, allowing default translations.  Any output
   sequences not bound in a matched section will be loaded from the
   default section if they are bound there.
 
@@ -809,7 +809,7 @@ read_config_file(void)
 }
 
 translation *
-get_translation(char *win_title)
+get_translation(char *win_title, char *win_class)
 {
   translation *tr;
 
@@ -817,6 +817,12 @@ get_translation(char *win_title)
   tr = first_translation_section;
   while (tr != NULL) {
     if (tr->is_default) {
+      return tr;
+    }
+    // AG: We first try to match the class name, since it usually provides
+    // better identification clues.
+    if (win_class && *win_class &&
+	regexec(&tr->regex, win_class, 0, NULL, 0) == 0) {
       return tr;
     }
     if (regexec(&tr->regex, win_title, 0, NULL, 0) == 0) {

--- a/readconfig.c
+++ b/readconfig.c
@@ -652,7 +652,7 @@ read_config_file(void)
   char *home;
   char *line;
   char *s;
-  char *name;
+  char *name = NULL;
   char *regex;
   char *tok;
   char *which_key;

--- a/readconfig.c
+++ b/readconfig.c
@@ -3,6 +3,8 @@
 
   Copyright 2013 Eric Messick (FixedImagePhoto.com/Contact)
 
+  Copyright 2018 Albert Graef <aggraef@gmail.com>, various improvements
+
   Read and process the configuration file ~/.shuttlepro
 
   Lines starting with # are comments.
@@ -24,7 +26,7 @@
   Each "[name] regex" line introduces the list of key and shuttle
   translations for the named translation class.  The name is only used
   for debugging output, and needn't be unique.  The following lines
-  with K, S, and J labels indicate what output should be produced for
+  with K, S, I and J labels indicate what output should be produced for
   the given keypress, shuttle position, shuttle direction, or jog direction.
 
   output is a sequence of one or more key codes with optional up/down

--- a/shuttle.h
+++ b/shuttle.h
@@ -95,3 +95,5 @@ typedef struct _translation {
 } translation;
 
 extern translation *get_translation(char *win_title);
+extern void print_stroke_sequence(char *name, char *up_or_down, stroke *s);
+extern int debug_keys;

--- a/shuttle.h
+++ b/shuttle.h
@@ -94,6 +94,6 @@ typedef struct _translation {
   stroke *jog[NUM_JOGS];
 } translation;
 
-extern translation *get_translation(char *win_title);
+extern translation *get_translation(char *win_title, char *win_class);
 extern void print_stroke_sequence(char *name, char *up_or_down, stroke *s);
 extern int debug_keys;

--- a/shuttle.h
+++ b/shuttle.h
@@ -67,6 +67,7 @@
 
 #define NUM_KEYS 15
 #define NUM_SHUTTLES 15
+#define NUM_SHUTTLE_INCRS 2
 #define NUM_JOGS 2
 
 typedef struct _stroke {
@@ -78,7 +79,8 @@ typedef struct _stroke {
 #define KJS_KEY_DOWN 1
 #define KJS_KEY_UP 2
 #define KJS_SHUTTLE 3
-#define KJS_JOG 4
+#define KJS_SHUTTLE_INCR 4
+#define KJS_JOG 5
 
 typedef struct _translation {
   struct _translation *next;
@@ -88,6 +90,7 @@ typedef struct _translation {
   stroke *key_down[NUM_KEYS];
   stroke *key_up[NUM_KEYS];
   stroke *shuttle[NUM_SHUTTLES];
+  stroke *shuttle_incr[NUM_SHUTTLE_INCRS];
   stroke *jog[NUM_JOGS];
 } translation;
 

--- a/shuttle.h
+++ b/shuttle.h
@@ -1,5 +1,6 @@
 
 // Copyright 2013 Eric Messick (FixedImagePhoto.com/Contact)
+// Copyright 2018 Albert Graef <aggraef@gmail.com>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/shuttle.h
+++ b/shuttle.h
@@ -96,4 +96,6 @@ typedef struct _translation {
 
 extern translation *get_translation(char *win_title, char *win_class);
 extern void print_stroke_sequence(char *name, char *up_or_down, stroke *s);
-extern int debug_keys;
+extern int debug_regex, debug_strokes, debug_keys;
+extern int default_debug_regex, default_debug_strokes, default_debug_keys;
+extern char *config_file_name;

--- a/shuttlepro.c
+++ b/shuttlepro.c
@@ -88,10 +88,36 @@ void
 send_stroke_sequence(translation *tr, int kjs, int index)
 {
   stroke *s;
+  char key_name[100];
 
   s = fetch_stroke(tr, kjs, index);
   if (s == NULL) {
     s = fetch_stroke(default_translation, kjs, index);
+  }
+  if (debug_keys && s) {
+    switch (kjs) {
+    case KJS_SHUTTLE:
+      sprintf(key_name, "S%d", index-7);
+      print_stroke_sequence(key_name, "", s);
+      break;
+    case KJS_SHUTTLE_INCR:
+      sprintf(key_name, "I%s", (index>0)?"R":"L");
+      print_stroke_sequence(key_name, "", s);
+      break;
+    case KJS_JOG:
+      sprintf(key_name, "J%s", (index>0)?"R":"L");
+      print_stroke_sequence(key_name, "", s);
+      break;
+    case KJS_KEY_UP:
+      sprintf(key_name, "K%d", index);
+      print_stroke_sequence(key_name, "U", s);
+      break;
+    case KJS_KEY_DOWN:
+    default:
+      sprintf(key_name, "K%d", index);
+      print_stroke_sequence(key_name, "D", s);
+      break;
+    }
   }
   while (s) {
     send_key(s->keysym, s->press);

--- a/shuttlepro.c
+++ b/shuttlepro.c
@@ -350,6 +350,14 @@ handle_event(EV ev)
   }
 }
 
+void help(char *progname)
+{
+  fprintf(stderr, "Usage: %s [-h] [-r rcfile] [-d[rsk]] device\n", progname);
+  fprintf(stderr, "-h print this message\n");
+  fprintf(stderr, "-r config file name (default: SHUTTLE_CONFIG_FILE variable or ~/.shuttlerc)\n");
+  fprintf(stderr, "-d debug (r = regex, s = strokes, k = keys; default: all)\n");
+  fprintf(stderr, "device is the name of the shuttle device to open\n");
+}
 
 int
 main(int argc, char **argv)
@@ -359,13 +367,53 @@ main(int argc, char **argv)
   char *dev_name;
   int fd;
   int first_time = 1;
+  int opt;
 
-  if (argc != 2) {
-    fprintf(stderr, "usage: shuttlepro <device>\n" );
+  while ((opt = getopt(argc, argv, "hd::r:")) != -1) {
+    switch (opt) {
+    case 'h':
+      help(argv[0]);
+      exit(0);
+    case 'd':
+      if (optarg && *optarg) {
+	const char *a = optarg;
+	while (*a) {
+	  switch (*a) {
+	  case 'r':
+	    default_debug_regex = 1;
+	    break;
+	  case 's':
+	    default_debug_strokes = 1;
+	    break;
+	  case 'k':
+	    default_debug_keys = 1;
+	    break;
+	  default:
+	    fprintf(stderr, "%s: unknown debugging option (-d), must be r, s or k\n", argv[0]);
+	    fprintf(stderr, "Try -h for help.\n");
+	    exit(1);
+	  }
+	  ++a;
+	}
+      } else {
+	default_debug_regex = default_debug_strokes = default_debug_keys = 1;
+      }
+      break;
+    case 'r':
+      config_file_name = optarg;
+      break;
+    default:
+      fprintf(stderr, "Try -h for help.\n");
+      exit(1);
+    }
+  }
+
+  if (optind >= argc || optind+1 < argc) {
+    help(argv[0]);
     exit(1);
   }
 
-  dev_name = argv[1];
+  dev_name = argv[optind];
 
   initdisplay();
 

--- a/shuttlepro.c
+++ b/shuttlepro.c
@@ -5,6 +5,8 @@
 
  Copyright 2013 Eric Messick (FixedImagePhoto.com/Contact)
 
+ Copyright 2018 Albert Graef <aggraef@gmail.com>, various improvements
+
  Based on a version (c) 2006 Trammell Hudson <hudson@osresearch.net>
 
  which was in turn


### PR DESCRIPTION
Hi Eric, I'm not sure whether you're still maintaining this, but I recently bought one of these devices, and was very happy to find your program! It still compiles and works without a hitch. I've added a few things to make it easier to use in our lab, and I thought I might as well put up a PR in case you're interested. (If you aren't, then just let me know, and I'll just keep maintaining it on my own fork.)

What's in this PR:

- New `IL` and `IR` (incremental shuttle) bindings which work like `JL` and `JR`, but use the shuttle instead. This makes it a lot easier to set up some software, specifically the Shotcut video editor.

- A `DEBUG_KEYS` option which outputs keybindings as they are being executed, in the same format as `DEBUG_STROKES`.

- In addition to `WM_NAME`, also try to match the `WM_CLASS` property of a window. This makes it easier to set up some applications which don't have the application name in their title bar, because usually the `WM_CLASS` property *will* have some more application-specific clues in it.

- Also added a few program options to set the shuttlerc filename and select debugging options from the command line.

- If no device name is given on the command line, the program tries to locate a suitable device on its own, so it's usually not necessary to explicitly specify the device name any more (also obviating the need for the shuttle script, but I've kept that for now).

The changes aren't all that intrusive IMHO and should maintain backward compatibility in most cases, so I hope that you'll consider these for inclusion. I also have a second, more intrusive changeset which adds MIDI translations and the capability to output MIDI messages via Jack MIDI (great for DAW programs and the like), but I'll keep that for later, as it builds on the present PR.

Thanks, Albert